### PR TITLE
 Load dnlib with reflection to avoid versions conflict

### DIFF
--- a/dnSpy.Loader/Splash.cs
+++ b/dnSpy.Loader/Splash.cs
@@ -1,5 +1,4 @@
-﻿using dnlib.DotNet;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -34,8 +33,7 @@ namespace dnSpy.Loader
         }
 
         private void BackgroundWorker1_DoWork(object sender, System.ComponentModel.DoWorkEventArgs e) {
-            ModuleDefMD mod = ModuleDefMD.Load(myFilePath);
-            Assembly asm = Assembly.LoadFile(mod.Location);
+            Assembly asm = Assembly.LoadFile(dnlibWrapper.GetModuleLocation(myFilePath));
 
             asm.ManifestModule.GetPEKind(out PortableExecutableKinds peKind, out ImageFileMachine machine);
 

--- a/dnSpy.Loader/dnSpy.Loader.csproj
+++ b/dnSpy.Loader/dnSpy.Loader.csproj
@@ -36,10 +36,6 @@
     <StartupObject>dnSpy.Loader.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dnlib, Version=3.1.0.0, Culture=neutral, PublicKeyToken=50e96378b6e77999, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>bin\Debug\dnlib.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -52,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="dnlibWrapper.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/dnSpy.Loader/dnlibWrapper.cs
+++ b/dnSpy.Loader/dnlibWrapper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnSpy.Loader
+{
+	class dnlibWrapper
+	{
+		internal static string GetModuleLocation(string assemblyLocation)
+		{
+			var dnlib = Assembly.Load("dnlib");
+			var ModuleDefMD = dnlib.GetType("dnlib.DotNet.ModuleDefMD");
+			var ModuleCreationOptions = dnlib.GetType("dnlib.DotNet.ModuleCreationOptions");
+			var Load = ModuleDefMD.GetMethod("Load", new Type[] { typeof(string), ModuleCreationOptions });
+			var Location = ModuleDefMD.GetProperty("Location");
+
+			var mod = Load.Invoke(null, new object[] { assemblyLocation, null });
+			return (string)Location.GetValue(mod);
+		}
+	}
+}


### PR DESCRIPTION
The library dnlib is removed from references, now it's loaded with reflection to avoid conflict of different versions, ex: in my case there was a newer version (3.2.0) in dnspy directory so the loader couldn't run when an argument is provided (the background worker could not run)